### PR TITLE
Request Internet permission in AndroidManifest.xml

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -78,6 +78,10 @@
             </feature>
         </config-file>
 
+        <config-file target="AndroidManifest.xml" parent="/manifest">
+            <uses-permission android:name="android.permission.INTERNET" />
+        </config-file>
+        
         <source-file src="src/android/com/synconset/CordovaHTTP/CordovaHttp.java" target-dir="src/com/synconset" />
         <source-file src="src/android/com/synconset/CordovaHTTP/CordovaHttpGet.java" target-dir="src/com/synconset" />
         <source-file src="src/android/com/synconset/CordovaHTTP/CordovaHttpPost.java" target-dir="src/com/synconset" />


### PR DESCRIPTION
@EddyVerbruggen We should automatically add the Internet permission as otherwise users would have to do it manually in order to actually access the remote server.